### PR TITLE
fix: remove final trailing whitespace in CLAUDE.md

### DIFF
--- a/docs/core/CLAUDE.md
+++ b/docs/core/CLAUDE.md
@@ -637,6 +637,6 @@ To create new standards that integrate with this system:
 ## Related Standards
 
 - [Knowledge Management Standards](./docs/standards/KNOWLEDGE_MANAGEMENT_STANDARDS.md) - Core architecture principles
-- [Model Context Protocol Standards](./docs/standards/MODEL_CONTEXT_PROTOCOL_STANDARDS.md) - 
+- [Model Context Protocol Standards](./docs/standards/MODEL_CONTEXT_PROTOCOL_STANDARDS.md) -
   LLM optimization patterns for MCP
 - [Compliance Standards](./docs/standards/COMPLIANCE_STANDARDS.md) - NIST 800-53r5 control tagging guidelines


### PR DESCRIPTION
## Summary
- Fixed the remaining trailing whitespace issue in `docs/core/CLAUDE.md` line 640
- This was causing the Standards Compliance Template workflow to fail
- The fix removes trailing whitespace after the dash in the MCP standards reference line

## Test plan
- [x] Local whitespace check script passes
- [x] Pre-commit hooks pass
- [ ] GitHub Actions workflows should now pass

🤖 Generated with [Claude Code](https://claude.ai/code)