### PR TITLE
fix(ci): unbreak Pre-commit Checks job (pretty-format-json reformatting lockfiles)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,11 +93,12 @@ repos:
         exclude: |
           (?x)^(
               .*\.vscode/.*\.json$|
-              package-lock\.json$|
+              .*package-lock\.json$|
               .*node_modules/.*\.json$|
               .*\.min\.json$|
               .*tsconfig.*\.json$|
-              .*\.eslintrc.*\.json$
+              .*\.eslintrc.*\.json$|
+              reports/generated/.*\.json$
           )$
 
   # ============================================================================

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,6 +8,7 @@ community a harassment-free experience for everyone.
 ## Our Standards
 
 Examples of behavior that contributes to a positive environment:
+
 - Using welcoming and inclusive language
 - Being respectful of differing viewpoints
 - Gracefully accepting constructive criticism


### PR DESCRIPTION
## Problem

The **Pre-commit Checks** CI job (`pre-commit run --all-files`) fails on every open Dependabot PR (#84-#99). The failing step is `Run pre-commit`.

The failure is **genuine on `master` itself** — it is not specific to any Dependabot change. The Dependabot PRs simply inherit the broken state of `master`.

## Root cause

The `pretty-format-json` hook runs with `--autofix` and reformatted two files it should never touch, then exited non-zero:

1. **`standards/compliance/package-lock.json`** — the exclude pattern was `package-lock\.json$` inside a `(?x)^(...)$`-anchored regex. Anchored that way, it only matches a *top-level* `package-lock.json` and misses the nested one. npm lockfiles must preserve npm's own key ordering, so the hook rewrote ~4308 lines and failed.

2. **`reports/generated/structure-audit.json`** — a script-generated artifact (`scripts/generate-audit-reports.py` writes it with `indent=4`), so the hook reformatted it (2-space + sorted keys) on every run.

Separately, `markdownlint --fix` flagged a real violation in `CODE_OF_CONDUCT.md`: a list was missing a blank line above it (MD032).

## Fix

- `.pre-commit-config.yaml`: changed the `pretty-format-json` exclude from `package-lock\.json$` to `.*package-lock\.json$` so lockfiles at **any directory depth** are skipped, and added `reports/generated/.*\.json$` so generated reports are not reformatted (they are regenerated by scripts, not hand-maintained).
- `CODE_OF_CONDUCT.md`: applied markdownlint's MD032 fix (blank line before list).

No hooks were disabled — both `pretty-format-json` and `markdownlint` remain active. The exclude scoping was simply corrected to its intended behavior.

## Verification

Ran the exact CI command locally:

```
SKIP=no-commit-to-branch pre-commit run --all-files
# exit code: 0  — all hooks pass
```

## Impact

This unblocks the **Pre-commit Checks** job for all open Dependabot PRs **#84-#99**. After this merges, those PRs can be rebased/re-run and will pass the pre-commit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)